### PR TITLE
confirm and reject in Loans.sol updated to take the loanie address of…

### DIFF
--- a/Solidity/contracts/Loans.sol
+++ b/Solidity/contracts/Loans.sol
@@ -73,10 +73,12 @@ contract Loans {
   }
 
   
-  function confirmLoan(uint256 _loanId, address _loanie)
+  function confirmLoan(uint256 _loanId)
     public
     returns(bool)
   {
+    address _loanie = tx.origin;
+
     int256 intIndex = searchPending(_loanId, _loanie);
     if(intIndex == -1)
       return false;
@@ -98,7 +100,9 @@ contract Loans {
     return true;
 
   }
-  function rejectLoan(uint256 _loanId, address _loanie)public returns(bool){
+  function rejectLoan(uint256 _loanId)public returns(bool){
+    address _loanie = tx.origin;
+
     int256 intIndex = searchPending(_loanId, _loanie);
     if(intIndex == -1)
       return false;

--- a/Solidity/contracts/User.sol
+++ b/Solidity/contracts/User.sol
@@ -32,9 +32,9 @@ contract User {
         address loanie = msg.sender;
         Loans loansContract = Loans(loansContractAddress);
         if (_type)
-          loansContract.confirmLoan(_loanId, loanie);
+          loansContract.confirmLoan(_loanId);
         else
-          loansContract.rejectLoan(_loanId, loanie);
+          loansContract.rejectLoan(_loanId);
         return true;
     }
 


### PR DESCRIPTION
… the of the caller, not to send it as an argument (for security reasons).